### PR TITLE
Fix varlist include path for hyprutils

### DIFF
--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -1,5 +1,5 @@
 #include <hyprland/src/Compositor.hpp>
-#include <hyprland/src/helpers/VarList.hpp>
+#include <hyprutils/string/VarList.hpp>
 #include <hyprland/src/includes.hpp>
 #include <hyprland/src/managers/LayoutManager.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>


### PR DESCRIPTION
With 0.41.1, some utilities moved to hyprutils. Most includes are still fine, but VarList now also lives there instead of main source