### PR TITLE
Add argument to "scroller:movefocus" making cursor wrap for this dispatcher optional

### DIFF
--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -76,8 +76,12 @@ namespace {
             return;
 
         auto args = CVarList(arg);
+        bool move_cursor = true;
+        if (args[1] == "0" || args[1] == "false" || args[1] == "no") {
+            move_cursor = false;
+        }
         if (auto direction = parse_move_arg(args[0])) {
-            g_ScrollerLayout->move_focus(workspace, *direction);
+            g_ScrollerLayout->move_focus(workspace, *direction, move_cursor);
         }
     }
 

--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -1788,21 +1788,22 @@ void ScrollerLayout::cycle_window_size(int workspace, int step)
     s->resize_active_column(step);
 }
 
-static void switch_to_window(PHLWINDOW window)
-{
+static void switch_to_window(PHLWINDOW window, bool move_cursor) {
     if (window == g_pCompositor->m_pLastWindow.lock())
         return;
 
     g_pInputManager->unconstrainMouse();
     g_pCompositor->focusWindow(window);
+    if (move_cursor) {
     g_pCompositor->warpCursorTo(window->middle());
+    }
 
     g_pInputManager->m_pForcedFocus = window;
     g_pInputManager->simulateMouseMovement();
     g_pInputManager->m_pForcedFocus.reset();
 }
 
-void ScrollerLayout::move_focus(int workspace, Direction direction)
+void ScrollerLayout::move_focus(int workspace, Direction direction, bool move_cursor)
 {
     static auto* const *focus_wrap = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:scroller:focus_wrap")->getDataStaticPtr();
     auto s = getRowForWorkspace(workspace);
@@ -1836,7 +1837,7 @@ void ScrollerLayout::move_focus(int workspace, Direction direction)
             return;
         }
     }
-    switch_to_window(s->get_active_window());
+    switch_to_window(s->get_active_window(), move_cursor);
 }
 
 void ScrollerLayout::move_window(int workspace, Direction direction) {
@@ -1846,7 +1847,7 @@ void ScrollerLayout::move_window(int workspace, Direction direction) {
     }
 
     s->move_active_column(direction);
-    switch_to_window(s->get_active_window());
+    switch_to_window(s->get_active_window(), true);
 }
 
 void ScrollerLayout::align_window(int workspace, Direction direction) {
@@ -1925,7 +1926,7 @@ void ScrollerLayout::marks_delete(const std::string &name) {
 void ScrollerLayout::marks_visit(const std::string &name) {
     PHLWINDOW window = marks.visit(name);
     if (window != nullptr)
-        switch_to_window(window);
+        switch_to_window(window, true);
 }
 
 void ScrollerLayout::marks_reset() {

--- a/src/scroller.h
+++ b/src/scroller.h
@@ -37,7 +37,7 @@ public:
 
     // New Dispatchers
     void cycle_window_size(int workspace, int step);
-    void move_focus(int workspace, Direction);
+    void move_focus(int workspace, Direction, bool);
     void move_window(int workspace, Direction);
     void align_window(int workspace, Direction);
     void admit_window_left(int workspace);


### PR DESCRIPTION
i'm writing a layer shell tool which can call this dispatcher when clicking something on the layer surface, it needs the cursor to not move when calling `movefocus`.
if this is not needed or it can be done in some other ways, i can close this pr.