### PR TITLE
Fix call to window data update

### DIFF
--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -1649,7 +1649,7 @@ void ScrollerLayout::fullscreenRequestForWindow(PHLWINDOW window,
             window->m_vRealPosition = window->m_vLastFloatingPosition;
             window->m_vRealSize = window->m_vLastFloatingSize;
 
-            window->updateSpecialRenderData();
+            window->updateWindowData();
         } else {
             // if it now got fullscreen, make it fullscreen
 


### PR DESCRIPTION
In commit https://github.com/hyprwm/hyprland/commit/a443902abca6549839910720b80bd01faf10f387, the call was renamed. In some places they switched to `pWindow->unsetWindowData(PRIORITY_LAYOUT);` instead, for optimization I assume.