### PR TITLE
Update recalculateMonitor parameter type from int to MONITORID

### DIFF
--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -1578,7 +1578,7 @@ bool ScrollerLayout::isWindowTiled(PHLWINDOW window)
     Called when the monitor requires a layout recalculation
     this usually means reserved area changes
 */
-void ScrollerLayout::recalculateMonitor(const int &monitor_id)
+void ScrollerLayout::recalculateMonitor(const MONITORID &monitor_id)
 {
     auto PMONITOR = g_pCompositor->getMonitorFromID(monitor_id);
     if (!PMONITOR)

--- a/src/scroller.h
+++ b/src/scroller.h
@@ -17,7 +17,7 @@ public:
                                        eDirection = DIRECTION_DEFAULT);
     virtual bool isWindowTiled(PHLWINDOW);
     virtual void onWindowRemovedTiling(PHLWINDOW);
-    virtual void recalculateMonitor(const int &monitor_id);
+    virtual void recalculateMonitor(const MONITORID &monitor_id);
     virtual void recalculateWindow(PHLWINDOW);
     virtual void resizeActiveWindow(const Vector2D &delta, eRectCorner corner,
                                     PHLWINDOW pWindow = nullptr);


### PR DESCRIPTION
Issue occured for hyprland version:
```
Hyprland, built from branch main at commit 1840a907a8c6b1f59cfa6738a8f46b320e8df8b1  (renderbuffer: ensure framebuffer gets deleted (7363)).
Tag: v0.42.0-28-g1840a907
```
Error:
```
In file included from /usr/include/c++/14.2.1/bits/shared_ptr_base.h:59,
                 from /usr/include/c++/14.2.1/bits/shared_ptr.h:53,
                 from /usr/include/c++/14.2.1/chrono:49,
                 from /usr/include/hyprland/src/debug/Log.hpp:6,
                 from /usr/include/hyprland/src/config/ConfigManager.hpp:6,
                 from /home/axl/per/hyprscrollezr/src/main.cpp:1:
/usr/include/c++/14.2.1/bits/unique_ptr.h: In instantiation of ‘constexpr std::__detail::__unique_ptr_t<_Tp> std::make_unique(_Args&& ...) [with _Tp = ScrollerLayout; _Args = {}; __detail::__unique_ptr_t<_Tp> = __detail::__unique_ptr_t<ScrollerLayout>]’:
/home/axl/per/hyprscroller/src/main.cpp:21:56:   required from here
   21 |     g_ScrollerLayout = std::make_unique<ScrollerLayout>();
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/usr/include/c++/14.2.1/bits/unique_ptr.h:1076:30: error: invalid new-expression of abstract class type ‘ScrollerLayout’
 1076 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/axl/per/hyprscroller/src/main.cpp:6:
/home/axl/per/hyprscroller/src/scroller.h:11:7: note:   because the following virtual functions are pure within ‘ScrollerLayout’:
   11 | class ScrollerLayout : public IHyprLayout {
      |       ^~~~~~~~~~~~~~
In file included from /home/axl/per/hyprscroller/src/scroller.h:1:
/usr/include/hyprland/src/layout/IHyprLayout.hpp:66:18: note:     ‘virtual void IHyprLayout::recalculateMonitor(const MONITORID&)’
   66 |     virtual void recalculateMonitor(const MONITORID&) = 0;
      |                  ^~~~~~~~~~~~~~~~~~
make[3]: *** [CMakeFiles/hyprscroller.dir/build.make:76: CMakeFiles/hyprscroller.dir/src/main.cpp.o] Error 1
```
