### PR TITLE
Commit Pins for Nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725199881,
-        "narHash": "sha256-jsmipf/u1GFZE5tBUkr56CHMN6VpUWCAjfLIhvQijU0=",
+        "lastModified": 1722347739,
+        "narHash": "sha256-rAoh+K6KG+b1DwSWtqRVocdojnH6nGk6q07mNltoUSM=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "f8a687dd29ff019657498f1bd14da2fbbf0e604b",
+        "rev": "7c3565f9bedc7cb601cc0baa14792247e4dc1d5a",
         "type": "github"
       },
       "original": {
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722623071,
-        "narHash": "sha256-sLADpVgebpCBFXkA1FlCXtvEPu1tdEsTfqK1hfeHySE=",
+        "lastModified": 1721330371,
+        "narHash": "sha256-aYlHTWylczLt6ERJyg6E66Y/XSCbVL7leVcRuJmVbpI=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "912d56025f03d41b1ad29510c423757b4379eb1c",
+        "rev": "4493a972b48f9c3014befbbf381ed5fff91a65dc",
         "type": "github"
       },
       "original": {
@@ -74,16 +74,17 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1725367654,
-        "narHash": "sha256-1hiNRCEdSZLfyH2y06S+gqUbiSwbwdktStPSJuPesaM=",
-        "ref": "refs/heads/main",
-        "rev": "9b54342baa27d8de0460e1103ec4c3cc65592ed8",
-        "revCount": 5182,
+        "lastModified": 1723058230,
+        "narHash": "sha256-deu8zvgseDg2gQEnZiCda4TrbA6pleE9iItoZlsoMtE=",
+        "ref": "refs/tags/v0.42.0",
+        "rev": "9a09eac79b85c846e3a865a9078a3f8ff65a9259",
+        "revCount": 5069,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
       },
       "original": {
+        "ref": "refs/tags/v0.42.0",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -132,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725188252,
-        "narHash": "sha256-yBH8c4GDaEAtBrh+BqIlrx5vp6gG/Gu8fQQK63KAQgs=",
+        "lastModified": 1721324361,
+        "narHash": "sha256-BiJKO0IIdnSwHQBSrEJlKlFr753urkLE48wtt0UhNG4=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "c12ab785ce1982f82594aff03b3104c598186ddd",
+        "rev": "adbefbf49664a6c2c8bf36b6487fd31e3eb68086",
         "type": "github"
       },
       "original": {
@@ -157,11 +158,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724966483,
-        "narHash": "sha256-WXDgKIbzjYKczxSZOsJplCS1i1yrTUpsDPuJV/xpYLo=",
+        "lastModified": 1722098849,
+        "narHash": "sha256-D3wIZlBNh7LuZ0NaoCpY/Pvu+xHxIVtSN+KkWZYvvVs=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "8976e3f6a5357da953a09511d0c7f6a890fb6ec2",
+        "rev": "5dcbbc1e3de40b2cecfd2007434d86e924468f1f",
         "type": "github"
       },
       "original": {
@@ -197,11 +198,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725103162,
-        "narHash": "sha256-Ym04C5+qovuQDYL/rKWSR+WESseQBbNAe5DsXNx5trY=",
+        "lastModified": 1722185531,
+        "narHash": "sha256-veKR07psFoJjINLC8RK4DiLniGGMgF3QMlS4tb74S6k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12228ff1752d7b7624a54e9c1af4b222b3c1073b",
+        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
         "type": "github"
       },
       "original": {
@@ -248,11 +249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725203932,
-        "narHash": "sha256-VLULC/OnI+6R9KEP2OIGk+uLJJsfRlaLouZ5gyFd2+Y=",
+        "lastModified": 1722365976,
+        "narHash": "sha256-Khdm+mDzYA//XaU0M+hftod+rKr5q9SSHSEuiQ0/9ow=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "2425e8f541525fa7409d9f26a8ffaf92a3767251",
+        "rev": "7f2a77ddf60390248e2a3de2261d7102a13e5341",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1725310138,
-        "narHash": "sha256-LgX5xG/xdfWxie6ia9M+Fc825EH93kcwu5CFzFqIe5g=",
+        "lastModified": 1725367654,
+        "narHash": "sha256-1hiNRCEdSZLfyH2y06S+gqUbiSwbwdktStPSJuPesaM=",
         "ref": "refs/heads/main",
-        "rev": "8f9887b0c9443d6c2559feeec411daecb9780a97",
-        "revCount": 5181,
+        "rev": "9b54342baa27d8de0460e1103ec4c3cc65592ed8",
+        "revCount": 5182,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,6 @@
     type = "git";
     url = "https://github.com/hyprwm/Hyprland";
     submodules = true;
-    ref = "refs/tags/v0.42.0";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,8 @@
           (substring 6 2 date)
         ]);
       version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
+      rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).hyprscroller.commit_pins;
+      commitPins = builtins.listToAttrs (map (p: { name = builtins.head p; value = builtins.elemAt p 1;}) rawCommitPins);
     in
     {
       packages = forAllSystems (
@@ -50,7 +52,10 @@
           hyprscroller = pkgs.stdenv.mkDerivation {
             pname = "hyprscroller";
             inherit version;
-            src = self;
+            src = builtins.fetchGit {
+              url = "https://github.com/dawsers/hyprscroller";
+              rev = commitPins.${hyprland.rev};
+            };
 
             nativeBuildInputs = [
               pkgs.cmake

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           (substring 4 2 date)
           (substring 6 2 date)
         ]);
-      rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).hyprscroller.commit_pins;
+      rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).repository.commit_pins;
       commitPins = builtins.listToAttrs (map (p: { name = builtins.head p; value = builtins.elemAt p 1;}) rawCommitPins);
       selfRev = commitPins.${hyprland.rev};
       version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}_${selfRev}";

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     type = "git";
     url = "https://github.com/hyprwm/Hyprland";
     submodules = true;
+    ref = "refs/tags/v0.42.0";
   };
 
   outputs =
@@ -37,9 +38,10 @@
           (substring 4 2 date)
           (substring 6 2 date)
         ]);
-      version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
       rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).hyprscroller.commit_pins;
       commitPins = builtins.listToAttrs (map (p: { name = builtins.head p; value = builtins.elemAt p 1;}) rawCommitPins);
+      selfRev = commitPins.${hyprland.rev};
+      version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}_${selfRev}";
     in
     {
       packages = forAllSystems (
@@ -54,7 +56,7 @@
             inherit version;
             src = builtins.fetchGit {
               url = "https://github.com/dawsers/hyprscroller";
-              rev = commitPins.${hyprland.rev};
+              rev = selfRev;
             };
 
             nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
         ]);
       rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).repository.commit_pins;
       commitPins = builtins.listToAttrs (map (p: { name = builtins.head p; value = builtins.elemAt p 1;}) rawCommitPins);
-      selfRev = commitPins.${hyprland.rev};
+      selfRev = "${substring 0 7 commitPins.${hyprland.rev} or "git"}";
       version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}_${selfRev}";
     in
     {
@@ -54,10 +54,10 @@
           hyprscroller = pkgs.stdenv.mkDerivation {
             pname = "hyprscroller";
             inherit version;
-            src = builtins.fetchGit {
+            src = if (commitPins ? ${hyprland.rev}) && (self ? rev) then (builtins.fetchGit {
               url = "https://github.com/dawsers/hyprscroller";
               rev = selfRev;
-            };
+            }) else ./.;
 
             nativeBuildInputs = [
               pkgs.cmake

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,16 @@
           (substring 6 2 date)
         ]);
       rawCommitPins = (builtins.fromTOML (builtins.readFile ./hyprpm.toml)).repository.commit_pins;
-      commitPins = builtins.listToAttrs (map (p: { name = builtins.head p; value = builtins.elemAt p 1;}) rawCommitPins);
+      commitPins = builtins.listToAttrs (
+        map (p: {
+          name = builtins.head p;
+          value = builtins.elemAt p 1;
+        }) rawCommitPins
+      );
       selfRev = "${substring 0 7 commitPins.${hyprland.rev} or "git"}";
-      version = "date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}_${selfRev}";
+      version = "date=${
+        mkDate (self.lastModifiedDate or "19700101")
+      }_${self.shortRev or "dirty"}_${selfRev}";
     in
     {
       packages = forAllSystems (
@@ -54,10 +61,14 @@
           hyprscroller = pkgs.stdenv.mkDerivation {
             pname = "hyprscroller";
             inherit version;
-            src = if (commitPins ? ${hyprland.rev}) && (self ? rev) then (builtins.fetchGit {
-              url = "https://github.com/dawsers/hyprscroller";
-              rev = selfRev;
-            }) else ./.;
+            src =
+              if (commitPins ? ${hyprland.rev}) && (self ? rev) then
+                (builtins.fetchGit {
+                  url = "https://github.com/dawsers/hyprscroller";
+                  rev = selfRev;
+                })
+              else
+                ./.;
 
             nativeBuildInputs = [
               pkgs.cmake


### PR DESCRIPTION
This allows the nix flake to share commit pins with hyprpm by reading `hyprpm.toml`, to minimize maintenance efforts. 

This requires users to set `inputs.hyprscroller.inputs.hyprland.follows = "<user's pinned hyprland input>"`

Example:
```nix
# in flake.nix
inputs = {
    hyprscroller = {
      url = "github:dawsers/hyprscroller";
      inputs.hyprland.follows = "hyprland";
    };
    hyprland = {
      type = "git";
      url = "https://github.com/hyprwm/Hyprland";
      submodules = true; # required by recent Hyprland versions
      ref = "refs/tags/v0.41.2"; # pin Hyprland version by tag
      # or pin by a revision that EXISTS in hyprpm.toml (see caveat below)
      # rev = <revision hash>;
    };
};
```

~~FIXME: Currently, this should fail (I think) if the user pins the Hyprland flake input to a revision that is not in `hyprpm.toml`. Should make hyprscroller just use `master` branch if Hyprland is unpinned or pinned to a revision not in `hyprpm.toml`~~

This is nice but a hack nevertheless - requires testing.