### PR TITLE
Fix build with non GCC compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,9 @@ pkg_check_modules(DEPS REQUIRED hyprutils hyprlang pixman-1 libdrm pangocairo)
 # Compile flags
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
-set(CMAKE_CXX_FLAGS "-fno-gnu-unique")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "-fno-gnu-unique")
+endif()
 
 add_library(hyprscroller SHARED
             src/main.cpp


### PR DESCRIPTION
The flag `fno-gnu-unique` is GCC specific and causes build fail with other compilers (i.e. Clang on FreeBSD).

Set this flag only if the used compiler ID matches 'GNU'.