### PR TITLE
chase ff9e059

### DIFF
--- a/src/scroller.cpp
+++ b/src/scroller.cpp
@@ -502,7 +502,6 @@ void ScrollerLayout::resizeActiveWindow(const Vector2D &delta,
     if (s == nullptr) {
         // Window is not tiled
         *PWINDOW->m_vRealSize = Vector2D(std::max((PWINDOW->m_vRealSize->goal() + delta).x, 20.0), std::max((PWINDOW->m_vRealSize->goal() + delta).y, 20.0));
-        PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal());
         PWINDOW->updateWindowDecos();
         return;
     }
@@ -538,7 +537,6 @@ void ScrollerLayout::fullscreenRequestForWindow(PHLWINDOW window,
 
                 window->unsetWindowData(PRIORITY_LAYOUT);
                 window->updateWindowData();
-                window->sendWindowSize(window->m_vRealSize->goal());
             }
         } else {
             // apply new pos and size being monitors' box
@@ -551,7 +549,6 @@ void ScrollerLayout::fullscreenRequestForWindow(PHLWINDOW window,
                             PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight};
                 *window->m_vRealPosition = Vector2D(box.x, box.y);
                 *window->m_vRealSize = Vector2D(box.w, box.h);
-                window->sendWindowSize(window->m_vRealSize->goal());
             }
         }
     } else {

--- a/src/window.h
+++ b/src/window.h
@@ -46,7 +46,6 @@ public:
         window->m_vSize = Vector2D(box.w, box.h);
         *window->m_vRealPosition = window->m_vPosition;
         *window->m_vRealSize = window->m_vSize;
-        window->sendWindowSize(window->m_vRealSize->goal());
     }
     bool is_window(PHLWINDOW w) const {
         return window == w;
@@ -66,7 +65,6 @@ public:
         window->m_vSize = Vector2D(std::max(window->m_vSize.x, 1.0), std::max(window->m_vSize.y, 1.0));
         *window->m_vRealSize = window->m_vSize;
         *window->m_vRealPosition = window->m_vPosition;
-        window->sendWindowSize(window->m_vRealSize->goal());
     }
 
     void move_to_bottom(double x, const Box &max, const Vector2D &gap_x, double gap) {
@@ -96,7 +94,6 @@ public:
         window->m_vSize = Vector2D(std::max(w - reserved.topLeft.x - reserved.bottomRight.x - gap_x.x - gap_x.y, 1.0), std::max(get_geom_h() - reserved.topLeft.y - reserved.bottomRight.y - gap0 - gap1, 1.0));
         *window->m_vRealPosition = window->m_vPosition;
         *window->m_vRealSize = window->m_vSize;
-        window->sendWindowSize(window->m_vRealSize->goal());
     }
     bool can_resize_width(double geomw, double maxw, const Vector2D &gap_x, double gap, double deltax) {
         // First, check if resize is possible or it would leave any window
@@ -180,7 +177,6 @@ private:
         w->m_vSize = mem.vSize;
         *w->m_vRealPosition = w->m_vPosition;
         *w->m_vRealSize = w->m_vSize;
-        w->sendWindowSize(w->m_vRealSize->goal());
     }
 
     PHLWINDOWREF window;


### PR DESCRIPTION
https://github.com/hyprwm/Hyprland/commit/ff9e059de6dd30c813270ff5a74053339cc94765 changed how `sendWindowSize` should be called

Since we set `m_vRealSize` in each place right before, and we don't set the `force` parameter, removing these calls achieves the desired result