### PR TITLE
Remove border_part_of_window check (git)

### DIFF
--- a/src/decorations.cpp
+++ b/src/decorations.cpp
@@ -151,9 +151,7 @@ eDecorationLayer SelectionBorders::getDecorationLayer() {
 }
 
 uint64_t SelectionBorders::getDecorationFlags() {
-    static auto PPARTOFWINDOW = CConfigValue<Hyprlang::INT>("general:border_part_of_window");
-
-    return *PPARTOFWINDOW && !doesntWantBorders() ? DECORATION_PART_OF_MAIN_WINDOW : 0;
+    return !doesntWantBorders() ? DECORATION_PART_OF_MAIN_WINDOW : 0;
 }
 
 std::string SelectionBorders::getDisplayName() {


### PR DESCRIPTION
Removed in d1ea18b492deb9acfd1f209a9d000107eea0ac3f, specifically
https://github.com/hyprwm/hyprland/commit/d1ea18b492deb9acfd1f209a9d000107eea0ac3f#diff-1ff4907a528959217122ac3ce5384121df70bf54328c361b0492815cb6d02c67L150-R150

Of course, this should be there until the next release, but for git users this crashes